### PR TITLE
Add Laboratory.check() for cleaner conditionals

### DIFF
--- a/library/laboratory/src/main/java/io/mehow/laboratory/Laboratory.kt
+++ b/library/laboratory/src/main/java/io/mehow/laboratory/Laboratory.kt
@@ -29,6 +29,11 @@ class Laboratory(private val storage: FeatureStorage) {
   @BlockingIoCall
   fun <T : Feature<T>> experimentBlocking(featureClass: Class<T>) = runBlocking { experiment(featureClass) }
 
+  suspend fun <T : Feature<T>> check(value: T) = experiment(value::class.java) == value
+
+  @BlockingIoCall
+  fun <T : Feature<T>> checkBlocking(value: T) = runBlocking { check(value) }
+
   suspend fun <T : Feature<*>> setFeature(feature: T) = storage.setFeature(feature)
 
   @BlockingIoCall

--- a/library/laboratory/src/test/java/io/mehow/laboratory/LaboratorySpec.kt
+++ b/library/laboratory/src/test/java/io/mehow/laboratory/LaboratorySpec.kt
@@ -64,6 +64,20 @@ class LaboratorySpec : DescribeSpec({
       }
     }
 
+    context("checking feature value") {
+      it("returns false for non-default value") {
+        val laboratory = Laboratory(NullStorage)
+
+        laboratory.check(DefaultFeature.A) shouldBe false
+      }
+
+      it("returns true for default value") {
+        val laboratory = Laboratory(NullStorage)
+
+        laboratory.check(DefaultFeature.B) shouldBe true
+      }
+    }
+
     val features = listOf(NoDefaultFeature::class, DefaultFeature::class, MultiDefaultFeature::class)
     for (feature in features) {
       verifyFeatureChanges(feature.java)


### PR DESCRIPTION
## Why?

To simplify conditionals.

Before:
```kotlin
if (laboratory.experiment<Feature>() == Feature.Option) {
  // ...
}
```
After:
```kotlin
if (laboratory.check(Feature.Option) {
  // ...
}
```

## Naming

Is hard. `check` _may be_ misleading because there's `kotlin.check` which throws `IllegalStateException`.

Alternatives:
1. `experimentIs(Feature.Option)` + `experimentIsBlocking(Feature.Option)`
This was the original name. `Is` is cool because it implies boolean value, however the blocking variant reads... not so well. Is the value blocking?
1. Thesaurus-mode: `analyze`, `confirm`, `examine`, `probe`, `prove`, `sample`, `verify`.