### PR TITLE
Move elevation from a theme attribute to a regular resource

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -4,12 +4,12 @@ on:
     branches:
       - master
     paths-ignore:
-      - './library/images/**'
+      - './library/docs/**'
       - '*.md'
       - '.github/CODEOWNERS'
   pull_request:
     paths-ignore:
-      - './library/images/**'
+      - './library/docs/**'
       - '*.md'
       - '.github/CODEOWNERS'
 

--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Renamed `feature`/`features` argument in `setFeature()` and `setFeatures()` methods to `value`/`values` respectively.
+- Elevation is no longer an attribute in the `IoMehowLaboratory.Theme` and a regular resource is used instead. This makes sure that when an Activity theme is overridden externally it won't crash for an unknown attribute.
 
 ### Removed
 - `generateFactory` property from `sourcedFeatureStorage()` method in Gradle plugin. It was added to the public API by a mistake and wasn't responsible for anything.

--- a/library/inspector/src/main/res/layout/io_mehow_laboratory_feature_group_item.xml
+++ b/library/inspector/src/main/res/layout/io_mehow_laboratory_feature_group_item.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/io_mehow_laboratory_spacing"
-    app:cardElevation="?io_mehow_laboratory_elevation"
+    app:cardElevation="@dimen/io_mehow_laboratory_elevation"
     >
 
   <LinearLayout

--- a/library/inspector/src/main/res/values-night/dimens.xml
+++ b/library/inspector/src/main/res/values-night/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <dimen name="io_mehow_laboratory_elevation">2dp</dimen>
+</resources>

--- a/library/inspector/src/main/res/values-night/themes.xml
+++ b/library/inspector/src/main/res/values-night/themes.xml
@@ -3,7 +3,6 @@
 
   <style name="IoMehowLaboratory.Theme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
     <item name="colorPrimary">#81d4fa</item>
-    <item name="io_mehow_laboratory_elevation">2dp</item>
   </style>
 
 </resources>

--- a/library/inspector/src/main/res/values/dimens.xml
+++ b/library/inspector/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <dimen name="io_mehow_laboratory_spacing">8dp</dimen>
+  <dimen name="io_mehow_laboratory_elevation">8dp</dimen>
 </resources>

--- a/library/inspector/src/main/res/values/themes.xml
+++ b/library/inspector/src/main/res/values/themes.xml
@@ -4,7 +4,6 @@
   <style name="IoMehowLaboratory.Theme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
     <item name="colorPrimary">#2196f3</item>
     <item name="colorPrimaryDark">#0069c0</item>
-    <item name="io_mehow_laboratory_elevation">8dp</item>
   </style>
 
 </resources>

--- a/library/inspector/src/main/res/values/values.xml
+++ b/library/inspector/src/main/res/values/values.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <attr format="dimension" name="io_mehow_laboratory_elevation" />
-</resources>


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

This allows to override LaboratoryActivity theme in the manifest without worrying about the elevation. For example this entry in the manifest would crash the inspector.

```xml
<activity
    android:name="io.mehow.laboratory.inspector.LaboratoryActivity"
    android:exported="false"
    android:launchMode="singleInstance"
    android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar"
    tools:node="replace" />
```

## :technologist: Changes
<!-- Which code did you change? How? -->

`io_mehow_laboratory_elevation` is now a regular resource instead of a theme attribute.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [ ] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/Laboratory/blob/master/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/Laboratory/tree/master/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/Laboratory/tree/master/sample) with relevant changes.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

N/A

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

N/A
