### PR TITLE
Enable blocking API through a single entry point

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `BlockingLaboratory` class that can read and write feature flags via blocking API.
+- `blocking()` function to `Laboratory` class that is an entry point to the blocking API.
+
+### Deprecated
+- All blocking functions on the `Laboratory` class. `BlockingLaboratory` available via `blocking()` function should be used instead.
+
 ## [0.9.1] - 2020-11-12
 
 ### Added

--- a/library/laboratory/src/main/java/io/mehow/laboratory/BlockingLaboratory.kt
+++ b/library/laboratory/src/main/java/io/mehow/laboratory/BlockingLaboratory.kt
@@ -1,0 +1,62 @@
+package io.mehow.laboratory
+
+import kotlinx.coroutines.runBlocking
+
+/**
+ * A blocking equivalent of [Laboratory].
+ */
+public class BlockingLaboratory internal constructor(
+  @PublishedApi internal val laboratory: Laboratory,
+) {
+  /**
+   * Returns the current option of the input [Feature]. Warning – this call can block the calling thread.
+   *
+   * @see BlockingIoCall
+   */
+  @BlockingIoCall
+  public inline fun <reified T : Feature<T>> experiment(): T = runBlocking { laboratory.experiment() }
+
+  /**
+   * Returns the current option of the input [Feature]. Warning – this call can block the calling thread.
+   *
+   * @see BlockingIoCall
+   */
+  @BlockingIoCall
+  public fun <T : Feature<T>> experiment(feature: Class<T>): T = runBlocking { laboratory.experiment(feature) }
+
+  /**
+   * Checks if a [Feature] is set to the input [option]. Warning – this call can block the calling thread.
+   *
+   * @see BlockingIoCall
+   */
+  @BlockingIoCall
+  public fun <T : Feature<T>> experimentIs(option: T): Boolean = runBlocking { laboratory.experimentIs(option) }
+
+  /**
+   * Sets a [Feature] to have the input [option]. Warning – this call can block the calling thread.
+   *
+   * @return `true` if the option was set successfully, `false` otherwise.
+   * @see BlockingIoCall
+   */
+  @BlockingIoCall
+  public fun <T : Feature<*>> setOption(option: T): Boolean = runBlocking { laboratory.setOption(option) }
+
+  /**
+   * Sets [Features][Feature] to have the input [options]. If [options] contains more than one option
+   * for the same feature flag, the last one should be applied. Warning – this call can block the calling thread.
+   *
+   * @return `true` if the option was set successfully, `false` otherwise.
+   * @see BlockingIoCall
+   */
+  @BlockingIoCall
+  public fun <T : Feature<*>> setOptions(vararg options: T): Boolean = runBlocking { laboratory.setOptions(*options) }
+
+  /**
+   * Removes all stored feature flag options. Warning – this call can block the calling thread.
+   *
+   * @return `true` if the option was set successfully, `false` otherwise.
+   * @see BlockingIoCall
+   */
+  @BlockingIoCall
+  public fun clear(): Boolean = runBlocking { laboratory.clear() }
+}


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

I'm not super happy with the blocking API. While it is off-putting to use (which is good) it is, at the same time, not very readable. Also it clutters `Laboratory` API. And being off-putting is done with the `@BlockingIoCall` anyway.

## :technologist: Changes
<!-- Which code did you change? How? -->

I introduced `BlockingLaboratory` that takes over the blocking API and that is available via `blocking()` function on `Laboratory`.

```kotlin
// Was
laboratory.experimentIsBlocking(SomeFeature.Option)

// Is
laboratory.blocking().experimentIs(SomeFeature.Option)
```

Alternatively I could just add a `public fun <T> blocking(func: suspend Laboratory.() -> T): T` function, and it could be used, for example, like this.

```kotlin
laboratory.blocking { experimentIs(SomeFeature.Option) }
```

However, the latter option may encourage putting too much code in the `func` block. And it is not available from Java which I might want to give a proper support at some point. Though it is unlikely.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [ ] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/master/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/master/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/master/sample) with relevant changes.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Nothing special to test. It is a simple delegation. You can check if `ReplaceWith` works correctly.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

N/A