### PR TITLE
Fix events dispatching when clearing shared preferences

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Shared preferences based `FeatureStorage` dispatches now changes to feature flag observers when `clear()` method is used. This fixes an issue with the QA module where it did not update the UI after resetting feature flags if shared preferences where used for feature flags persistence.
+
 ## [0.9.2] - 2020-11-18
 
 ### Added

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/LaboratoryActivity.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/LaboratoryActivity.kt
@@ -120,7 +120,7 @@ public class LaboratoryActivity : AppCompatActivity() {
 
     /**
      * Configures [LaboratoryActivity] with a default "Features" tab, where feature flags are taken from the
-     * [mainFactory]. Any additional tabs can be added in [externalFactories].Rename
+     * [mainFactory]. Any additional tabs can be added in [externalFactories].
      */
     public fun configure(
       laboratory: Laboratory,

--- a/library/shared-preferences/src/androidTest/java/io/mehow/laboratory/sharedpreferences/SharedPreferencesFeaturesStorageTest.kt
+++ b/library/shared-preferences/src/androidTest/java/io/mehow/laboratory/sharedpreferences/SharedPreferencesFeaturesStorageTest.kt
@@ -53,6 +53,18 @@ internal class SharedPreferencesFeaturesStorageTest {
 
     laboratory.experimentIs(FeatureA.A).shouldBeTrue()
   }
+
+  @Test fun informsObserversAfterClearingFeatureFlags() = runBlocking {
+    storage.observeFeatureName(FeatureA::class.java).test {
+      expectItem() shouldBe null
+
+      storage.setOption(FeatureA.B)
+      expectItem() shouldBe FeatureA.B.name
+
+      storage.clear()
+      expectItem() shouldBe null
+    }
+  }
 }
 
 private enum class FeatureA : Feature<FeatureA> {

--- a/library/shared-preferences/src/main/java/io/mehow/laboratory/sharedpreferences/SharedPreferencesFeatureStorage.kt
+++ b/library/shared-preferences/src/main/java/io/mehow/laboratory/sharedpreferences/SharedPreferencesFeatureStorage.kt
@@ -41,7 +41,11 @@ internal class SharedPreferencesFeatureStorage(
   }
 
   override suspend fun clear(): Boolean {
-    preferences.edit().clear().apply()
+    val editor = preferences.edit()
+    for (key in preferences.all.keys) {
+      editor.remove(key)
+    }
+    editor.apply()
     return true
   }
 }


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

There is an issue – #54.

## :technologist: Changes
<!-- Which code did you change? How? -->

Shared preferences keys are reset one by one instead of clearing whole shared preferences.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [x] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/master/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/master/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/master/sample) with relevant changes.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Run the sample. Also tests are written.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

Closes #54.