### PR TITLE
Indicate deprecated feature flags in the inspector

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Builder pattern for `LaboratoryActivity.Configuration` construction.
+- Visual representation of deprecated feature flags in the QA module.
+- Visual representation of deprecated feature flags can be configured via `LaboratoryActivity.Configuration` builder with `deprecationPhenotypeSelector()` and `deprecationAlignmentSelector()` functions.
+- Consumer ProGuard rules to `laboratory-inspector` to keep `@Deprecated` annotation.
 
 ### Deprecated
 - `LaboratoryActivity.Configuration(storage)` constructor. Use `LaboratoryActivity.Configuration.create(storage)` or `LaboratoryActivity.Configuration.builder()` instead.

--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Builder pattern for `LaboratoryActivity.Configuration` construction.
+
+### Deprecated
+- `LaboratoryActivity.Configuration(storage)` constructor. Use `LaboratoryActivity.Configuration.create(storage)` or `LaboratoryActivity.Configuration.builder()` instead.
+
 ## [0.9.4] - 2020-11-27
 
 ### Added

--- a/library/inspector/build.gradle
+++ b/library/inspector/build.gradle
@@ -5,6 +5,10 @@ plugins {
 
 android {
   resourcePrefix "io_mehow_laboratory_"
+
+  defaultConfig {
+    consumerProguardFile "io-mehow-laboratory-inspector.pro"
+  }
 }
 
 dependencies {

--- a/library/inspector/io-mehow-laboratory-inspector.pro
+++ b/library/inspector/io-mehow-laboratory-inspector.pro
@@ -1,0 +1,4 @@
+-keep @interface kotlin.Deprecated {
+  *;
+}
+-keepattributes RuntimeVisibleAnnotations

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/DeprecationAlignment.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/DeprecationAlignment.kt
@@ -1,0 +1,27 @@
+package io.mehow.laboratory.inspector
+
+/**
+ * Alignment of deprecated feature flags in a list.
+ */
+public enum class DeprecationAlignment {
+  /**
+   * Does not place feature flags in any particular place of a list.
+   */
+  Regular,
+
+  /**
+   * Places deprecated feature flags at the bottom of a list.
+   */
+  Bottom,
+  ;
+
+  /**
+   * Determines alignment of features flags in a list based on their [DeprecationLevel].
+   */
+  public fun interface Selector {
+    /**
+     * Selects [DeprecationAlignment] based on a feature flag deprecation level.
+     */
+    public fun select(level: DeprecationLevel): DeprecationAlignment
+  }
+}

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/DeprecationHandler.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/DeprecationHandler.kt
@@ -1,0 +1,10 @@
+package io.mehow.laboratory.inspector
+
+internal class DeprecationHandler(
+  private val phenotypeSelector: DeprecationPhenotype.Selector,
+  private val alignmentSelector: DeprecationAlignment.Selector,
+) {
+  fun getPhenotype(level: DeprecationLevel) = phenotypeSelector.select(level)
+
+  fun getAlignment(level: DeprecationLevel) = alignmentSelector.select(level)
+}

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/DeprecationPhenotype.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/DeprecationPhenotype.kt
@@ -1,0 +1,32 @@
+package io.mehow.laboratory.inspector
+
+/**
+ * UI representation of deprecated feature flags.
+ */
+public enum class DeprecationPhenotype {
+  /**
+   * Does not differentiate deprecated feature flags from not deprecated ones.
+   */
+  Show,
+
+  /**
+   * Strikes feature flag name through.
+   */
+  Strikethrough,
+
+  /**
+   * Removed feature flag from a list.
+   */
+  Hide,
+  ;
+
+  /**
+   * Determines UI representation of feature flags based on their [DeprecationLevel].
+   */
+  public fun interface Selector {
+    /**
+     * Selects [DeprecationPhenotype] based on a feature flag deprecation level.
+     */
+    public fun select(level: DeprecationLevel): DeprecationPhenotype
+  }
+}

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureAdapter.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureAdapter.kt
@@ -20,7 +20,7 @@ internal class FeatureAdapter(
   override fun onBindViewHolder(holder: FeatureViewHolder, position: Int) = holder.bind(getItem(position))
 
   private object DiffCallback : ItemCallback<FeatureUiModel>() {
-    override fun areItemsTheSame(old: FeatureUiModel, new: FeatureUiModel) = old.fqcn == new.fqcn
+    override fun areItemsTheSame(old: FeatureUiModel, new: FeatureUiModel) = old.type == new.type
 
     override fun areContentsTheSame(old: FeatureUiModel, new: FeatureUiModel): Boolean {
       return old.models.selected == new.models.selected && old.sources.selected == new.sources.selected

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureUiModel.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureUiModel.kt
@@ -1,10 +1,14 @@
 package io.mehow.laboratory.inspector
 
+import io.mehow.laboratory.Feature
+
 internal data class FeatureUiModel(
+  val type: Class<Feature<*>>,
   val name: String,
-  val fqcn: String,
   val models: List<OptionUiModel>,
   val sources: List<OptionUiModel>,
+  val deprecationAlignment: DeprecationAlignment?,
+  val deprecationPhenotype: DeprecationPhenotype?,
 ) {
   val description = models.firstOrNull()?.option?.description.orEmpty()
 
@@ -14,6 +18,15 @@ internal data class FeatureUiModel(
       ?.option
       ?.name
       ?.equals("Local", ignoreCase = true) ?: true
+
+  companion object {
+    private val firstAlignmentOrdinal = DeprecationAlignment.values().first()
+
+    val NaturalComparator = compareBy<FeatureUiModel>(
+        { it.deprecationAlignment ?: firstAlignmentOrdinal },
+        { it.name }
+    )
+  }
 }
 
 internal fun List<FeatureUiModel>.search(query: SearchQuery) = mapNotNull { uiModels ->

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureViewHolder.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureViewHolder.kt
@@ -1,9 +1,13 @@
 package io.mehow.laboratory.inspector
 
+import android.graphics.Paint.STRIKE_THRU_TEXT_FLAG
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.google.android.material.textview.MaterialTextView
+import io.mehow.laboratory.inspector.DeprecationPhenotype.Hide
+import io.mehow.laboratory.inspector.DeprecationPhenotype.Show
+import io.mehow.laboratory.inspector.DeprecationPhenotype.Strikethrough
 
 internal class FeatureViewHolder(
   itemView: View,
@@ -22,6 +26,11 @@ internal class FeatureViewHolder(
 
   fun bind(group: FeatureUiModel) {
     name.text = group.name
+    name.paintFlags = when (group.deprecationPhenotype) {
+      null, Show -> name.paintFlags and STRIKE_THRU_TEXT_FLAG.inv()
+      Strikethrough -> name.paintFlags or STRIKE_THRU_TEXT_FLAG
+      Hide -> name.paintFlags
+    }
     description.text = group.description
     description.isVisible = group.description.isNotBlank()
     options.render(group.models, group.isCurrentSourceLocal)

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/LaboratoryActivity.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/LaboratoryActivity.kt
@@ -84,6 +84,7 @@ public class LaboratoryActivity : AppCompatActivity(R.layout.io_mehow_laboratory
   ) {
     internal val laboratory = builder.laboratory
     private val featureFactories = builder.featureFactories
+    internal val deprecation = DeprecationHandler(builder.phenotypeSelector, builder.alignmentSelector)
 
     @Deprecated(
         message = "This method will be removed in 1.0.0. Use 'Configuration.create()' instead.",
@@ -112,6 +113,18 @@ public class LaboratoryActivity : AppCompatActivity(R.layout.io_mehow_laboratory
 
       override fun featureFactories(factories: Map<String, FeatureFactory>): BuildingStep = apply {
         this.featureFactories = factories
+      }
+
+      internal var phenotypeSelector = DeprecationPhenotype.Selector { DeprecationPhenotype.Strikethrough }
+
+      override fun deprecationPhenotypeSelector(selector: DeprecationPhenotype.Selector): BuildingStep = apply {
+        this.phenotypeSelector = selector
+      }
+
+      internal var alignmentSelector = DeprecationAlignment.Selector { DeprecationAlignment.Bottom }
+
+      override fun deprecationAlignmentSelector(selector: DeprecationAlignment.Selector): BuildingStep = apply {
+        this.alignmentSelector = selector
       }
 
       override fun build(): Configuration = Configuration(this)
@@ -158,6 +171,16 @@ public class LaboratoryActivity : AppCompatActivity(R.layout.io_mehow_laboratory
      * The final step of a fluent builder that can set optional parameters.
      */
     public interface BuildingStep {
+      /**
+       * Sets how deprecated feature flags will be displayed to the user.
+       */
+      public fun deprecationPhenotypeSelector(selector: DeprecationPhenotype.Selector): BuildingStep
+
+      /**
+       * Sets how deprecated feature flags will be sorted in a displayed group.
+       */
+      public fun deprecationAlignmentSelector(selector: DeprecationAlignment.Selector): BuildingStep
+
       /**
        * Creates a new [Configuration] with provided parameters.
        */

--- a/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelDeprecationSpec.kt
+++ b/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelDeprecationSpec.kt
@@ -1,0 +1,154 @@
+package io.mehow.laboratory.inspector
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.mehow.laboratory.Feature
+import io.mehow.laboratory.FeatureFactory
+import io.mehow.laboratory.Laboratory
+import io.mehow.laboratory.inspector.DeprecationAlignment.Bottom
+import io.mehow.laboratory.inspector.DeprecationAlignment.Regular
+import io.mehow.laboratory.inspector.DeprecationPhenotype.Hide
+import io.mehow.laboratory.inspector.DeprecationPhenotype.Show
+import io.mehow.laboratory.inspector.DeprecationPhenotype.Strikethrough
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlin.DeprecationLevel.ERROR
+import kotlin.DeprecationLevel.WARNING
+
+internal class GroupViewModelDeprecationSpec : DescribeSpec({
+  setMainDispatcher()
+
+  describe("deprecated feature flags") {
+    it("can be filtered out") {
+      val viewModel = GroupViewModel(DeprecationHandler(
+          phenotypeSelector = { Hide },
+          alignmentSelector = { Regular },
+      ))
+
+      val featureNames = viewModel.observeFeatureGroup().first().map(FeatureUiModel::name)
+
+      featureNames shouldContainExactly listOf("NotDeprecated")
+    }
+
+    it("can be struck through") {
+      val viewModel = GroupViewModel(DeprecationHandler(
+          phenotypeSelector = { Strikethrough },
+          alignmentSelector = { Regular },
+      ))
+
+      val featureNames = viewModel.observeFeatureGroup().first().map { it.name to it.deprecationPhenotype }
+
+      featureNames shouldContainExactly listOf(
+          "DeprecatedError" to Strikethrough,
+          "DeprecatedWarning" to Strikethrough,
+          "NotDeprecated" to null,
+      )
+    }
+
+    it("can be shown") {
+      val viewModel = GroupViewModel(DeprecationHandler(
+          phenotypeSelector = { Show },
+          alignmentSelector = { Regular },
+      ))
+
+      val featureNames = viewModel.observeFeatureGroup().first().map { it.name to it.deprecationPhenotype }
+
+      featureNames shouldContainExactly listOf(
+          "DeprecatedError" to Show,
+          "DeprecatedWarning" to Show,
+          "NotDeprecated" to null,
+      )
+    }
+
+    it("can be moved to bottom") {
+      val viewModel = GroupViewModel(DeprecationHandler(
+          phenotypeSelector = { Show },
+          alignmentSelector = { Bottom },
+      ))
+
+      val featureNames = viewModel.observeFeatureGroup().first().map { it.name to it.deprecationPhenotype }
+
+      featureNames shouldContainExactly listOf(
+          "NotDeprecated" to null,
+          "DeprecatedError" to Show,
+          "DeprecatedWarning" to Show,
+      )
+    }
+
+    it("can be selected based on deprecation level") {
+      val viewModel = GroupViewModel(DeprecationHandler(
+          phenotypeSelector = { if (it == WARNING) Strikethrough else Show },
+          alignmentSelector = { if (it == ERROR) Bottom else Regular },
+      ))
+
+      val featureNames = viewModel.observeFeatureGroup().first().map { it.name to it.deprecationPhenotype }
+
+      featureNames shouldContainExactly listOf(
+          "DeprecatedWarning" to Strikethrough,
+          "NotDeprecated" to null,
+          "DeprecatedError" to Show,
+      )
+    }
+  }
+})
+
+private object DeprecatedFeatureFactory : FeatureFactory {
+  override fun create(): Set<Class<Feature<*>>> {
+    @Suppress("UNCHECKED_CAST")
+    return setOf(
+        Class.forName("io.mehow.laboratory.inspector.DeprecatedWarning"),
+        Class.forName("io.mehow.laboratory.inspector.DeprecatedError"),
+        /*
+         * https://github.com/MiSikora/laboratory/issues/62
+         *
+         * Class.forName("io.mehow.laboratory.inspector.DeprecatedHidden"),
+         */
+        NotDeprecated::class.java
+    ) as Set<Class<Feature<*>>>
+  }
+}
+
+@Deprecated("", level = WARNING)
+private enum class DeprecatedWarning : Feature<@Suppress("DEPRECATION") DeprecatedWarning> {
+  Option,
+  ;
+
+  override val defaultOption get() = Option
+}
+
+@Deprecated("message", level = ERROR)
+private enum class DeprecatedError : Feature<@Suppress("DEPRECATION_ERROR") DeprecatedError> {
+  Option,
+  ;
+
+  override val defaultOption get() = Option
+}
+
+/*
+ * https://github.com/MiSikora/laboratory/issues/62
+ *
+ * @Deprecated("", level = HIDDEN)
+ * private enum class DeprecatedHidden : Feature<DeprecatedHidden> {
+ *   Option,
+ *   ;
+ *
+ *   override val defaultOption get() = Option
+ * }
+ */
+
+private enum class NotDeprecated : Feature<NotDeprecated> {
+  Option,
+  ;
+
+  override val defaultOption get() = Option
+}
+
+@Suppress("TestFunctionName")
+private fun GroupViewModel(
+  deprecationHandler: DeprecationHandler,
+) = GroupViewModel(
+    Laboratory.inMemory(),
+    DeprecatedFeatureFactory,
+    deprecationHandler,
+    emptyFlow(),
+)

--- a/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelFeatureSpec.kt
+++ b/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelFeatureSpec.kt
@@ -137,8 +137,6 @@ internal class GroupViewModelFeatureSpec : DescribeSpec({
   }
 })
 
-
-
 private object NoSourceFeatureFactory : FeatureFactory {
   override fun create(): Set<Class<Feature<*>>> {
     @Suppress("UNCHECKED_CAST")

--- a/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelFeatureSpec.kt
+++ b/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelFeatureSpec.kt
@@ -1,6 +1,7 @@
 package io.mehow.laboratory.inspector
 
 import app.cash.turbine.test
+import io.kotest.assertions.fail
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotContain
@@ -201,4 +202,9 @@ private enum class Sourced : Feature<Sourced> {
 private fun GroupViewModel(
   laboratory: Laboratory,
   factory: FeatureFactory,
-) = GroupViewModel(laboratory, factory, emptyFlow())
+) = GroupViewModel(
+    laboratory,
+    factory,
+    DeprecationHandler({ fail("Unexpected call") }, { fail("Unexpected call") }),
+    emptyFlow(),
+)

--- a/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelFilterSpec.kt
+++ b/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelFilterSpec.kt
@@ -2,6 +2,7 @@ package io.mehow.laboratory.inspector
 
 import app.cash.turbine.FlowTurbine
 import app.cash.turbine.test
+import io.kotest.assertions.fail
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.property.Arb
@@ -235,7 +236,12 @@ private enum class SourcedFeature : Feature<SourcedFeature> {
 @Suppress("TestFunctionName")
 private fun GroupViewModel(
   searchFlow: Flow<SearchQuery>,
-) = GroupViewModel(Laboratory.inMemory(), SearchFeatureFactory, searchFlow)
+) = GroupViewModel(
+    Laboratory.inMemory(),
+    SearchFeatureFactory,
+    DeprecationHandler({ fail("Unexpected call") }, { fail("Unexpected call") }),
+    searchFlow,
+)
 
 private suspend fun FlowTurbine<List<KClass<out Feature<*>>>>.expectAllFeatureFlags() {
   expectItem() shouldContainExactly listOf(

--- a/library/laboratory/src/main/java/io/mehow/laboratory/Laboratory.kt
+++ b/library/laboratory/src/main/java/io/mehow/laboratory/Laboratory.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.map
 /**
  * High-level API for interaction with feature flags. It allows to read and write their options.
  */
-public class Laboratory private constructor(
+public class Laboratory internal constructor(
   builder: Builder,
 ) {
   private val storage = builder.storage
@@ -176,7 +176,7 @@ public class Laboratory private constructor(
     public fun builder(): FeatureStorageStep = Builder()
   }
 
-  private class Builder : FeatureStorageStep, BuildingStep {
+  internal class Builder : FeatureStorageStep, BuildingStep {
     lateinit var storage: FeatureStorage
 
     override fun featureStorage(storage: FeatureStorage): BuildingStep = apply {

--- a/library/laboratory/src/main/java/io/mehow/laboratory/Laboratory.kt
+++ b/library/laboratory/src/main/java/io/mehow/laboratory/Laboratory.kt
@@ -212,7 +212,7 @@ public class Laboratory internal constructor(
     public fun defaultOptionFactory(factory: DefaultOptionFactory): BuildingStep
 
     /**
-     * Creates a new [Laboratory] with
+     * Creates a new [Laboratory] with provided parameters.
      */
     public fun build(): Laboratory
   }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -36,6 +36,7 @@ android {
   }
 
   buildTypes.debug.setMatchingFallbacks "release"
+  buildTypes.debug.minifyEnabled true
 
   variantFilter {
     setIgnore it.name != "debug"
@@ -57,6 +58,8 @@ laboratory {
 
   feature("ReportRootedDevice") {
     description = "Reports during cold start whether device is rooted"
+
+    deprecated("Sample deprecation")
 
     withOption("Enabled")
     withDefaultOption("Disabled")


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

There is an issue – #61 .

## :technologist: Changes
<!-- Which code did you change? How? -->

Deprecated annotation is read through reflection to determine deprecation level and represent it in the UI. Representation can be customised via methods on builder configuration.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [x] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/master/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/master/library/docs).
- [x] I updated the [sample](https://github.com/MiSikora/laboratory/tree/master/sample) with relevant changes.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Unit tests are written but you can check the sample and see that `ReportRootedDevice` feature flag has deprecated indicator.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

Closes #61.