### PR TITLE
Add suppression to warning and error deprecations in generator

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - `LaboratoryActivity.Configuration(storage)` constructor. Use `LaboratoryActivity.Configuration.create(storage)` or `LaboratoryActivity.Configuration.builder()` instead.
 
+### Fixed
+- Warning and error level deprecation on generated feature flags is now correctly suppressed.
+
 ## [0.9.4] - 2020-11-27
 
 ### Added

--- a/library/gradle-plugin/src/test/java/io/mehow/laboratory/gradle/GenerateFeatureFlagsTaskSpec.kt
+++ b/library/gradle-plugin/src/test/java/io/mehow/laboratory/gradle/GenerateFeatureFlagsTaskSpec.kt
@@ -578,7 +578,7 @@ internal class GenerateFeatureFlagsTaskSpec : StringSpec({
       |  message = "Deprecation message",
       |  level = DeprecationLevel.WARNING
       |)
-      |public enum class Feature : io.mehow.laboratory.Feature<Feature>
+      |public enum class Feature : io.mehow.laboratory.Feature<@Suppress("DEPRECATION") Feature>
     """.trimMargin("|")
   }
 
@@ -592,6 +592,7 @@ internal class GenerateFeatureFlagsTaskSpec : StringSpec({
     val feature = fixture.featureFile("Feature")
     feature.shouldExist()
 
+    // TODO: https://github.com/MiSikora/laboratory/issues/62
     feature.readText() shouldContain """
       |@Deprecated(
       |  message = "Deprecation message",


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

There is an issue – #63.

## :technologist: Changes
<!-- Which code did you change? How? -->

Generated feature flags have suppression added for type parameter when they are deprecated with warning or error level.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [x] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/master/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/master/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/master/sample) with relevant changes.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Unit tests were adjusted for changes.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

Closes #63.