### PR TITLE
Add detection of Markdown links from flag descriptions

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Visual representation of deprecated feature flags in the QA module.
 - Visual representation of deprecated feature flags can be configured via `LaboratoryActivity.Configuration` builder with `deprecationPhenotypeSelector()` and `deprecationAlignmentSelector()` functions.
 - Consumer ProGuard rules to `laboratory-inspector` to keep `@Deprecated` annotation.
+- QA module displays clickable hyperlinks from a feature flag description if it contains Markdown formatted links.
 
 ### Deprecated
 - `LaboratoryActivity.Configuration(storage)` constructor. Use `LaboratoryActivity.Configuration.create(storage)` or `LaboratoryActivity.Configuration.builder()` instead.

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureUiModel.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureUiModel.kt
@@ -5,13 +5,12 @@ import io.mehow.laboratory.Feature
 internal data class FeatureUiModel(
   val type: Class<Feature<*>>,
   val name: String,
+  val description: List<TextToken>,
   val models: List<OptionUiModel>,
   val sources: List<OptionUiModel>,
   val deprecationAlignment: DeprecationAlignment?,
   val deprecationPhenotype: DeprecationPhenotype?,
 ) {
-  val description = models.firstOrNull()?.option?.description.orEmpty()
-
   val hasMultipleSources = sources.size > 1
 
   val isCurrentSourceLocal = sources.firstOrNull(OptionUiModel::isSelected)

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureViewHolder.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureViewHolder.kt
@@ -1,6 +1,7 @@
 package io.mehow.laboratory.inspector
 
 import android.graphics.Paint.STRIKE_THRU_TEXT_FLAG
+import android.text.method.LinkMovementMethod
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
@@ -22,6 +23,7 @@ internal class FeatureViewHolder(
   init {
     sources.setOnSelectSourceListener(listener)
     options.setOnSelectFeatureListener(listener)
+    description.movementMethod = LinkMovementMethod.getInstance()
   }
 
   fun bind(group: FeatureUiModel) {
@@ -31,8 +33,8 @@ internal class FeatureViewHolder(
       Strikethrough -> name.paintFlags or STRIKE_THRU_TEXT_FLAG
       Hide -> name.paintFlags
     }
-    description.text = group.description
-    description.isVisible = group.description.isNotBlank()
+    description.setTextTokens(group.description)
+    description.isVisible = group.description.isNotEmpty()
     options.render(group.models, group.isCurrentSourceLocal)
     sources.render(group.sources)
     sources.isVisible = group.hasMultipleSources

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/GroupViewModel.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/GroupViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import io.mehow.laboratory.Feature
 import io.mehow.laboratory.FeatureFactory
 import io.mehow.laboratory.Laboratory
+import io.mehow.laboratory.description
 import io.mehow.laboratory.inspector.LaboratoryActivity.Configuration
 import io.mehow.laboratory.source
 import kotlinx.coroutines.Dispatchers
@@ -92,7 +93,15 @@ internal class GroupViewModel(
       val featureEmissions = observeOptions(laboratory)
       val sourceEmissions = sourceMetadata?.observeOptions(laboratory) ?: flowOf(emptyList())
       return featureEmissions.combine(sourceEmissions) { features, sources ->
-        FeatureUiModel(feature, simpleReadableName, features, sources, deprecationPlacement, deprecationPhenotype)
+        FeatureUiModel(
+            type = feature,
+            name = simpleReadableName,
+            description = TextToken.create(feature.description),
+            models = features,
+            sources = sources,
+            deprecationAlignment = deprecationPlacement,
+            deprecationPhenotype = deprecationPhenotype,
+        )
       }
     }
 

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/TextToken.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/TextToken.kt
@@ -1,0 +1,61 @@
+package io.mehow.laboratory.inspector
+
+import android.text.SpannableStringBuilder
+import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+import android.text.style.URLSpan
+import android.widget.TextView
+import androidx.core.text.buildSpannedString
+
+internal sealed class TextToken {
+  abstract fun buildSpan(builder: SpannableStringBuilder)
+
+  data class Regular(private val text: String) : TextToken() {
+    override fun buildSpan(builder: SpannableStringBuilder) {
+      builder.append(text)
+    }
+  }
+
+  data class Link(private val text: String, private val url: String) : TextToken() {
+    override fun buildSpan(builder: SpannableStringBuilder) {
+      val linkStart = builder.length
+      builder.append(text)
+      builder.setSpan(URLSpan(url), linkStart, builder.length, SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+  }
+
+  companion object {
+    internal val extractLinkRegex = """\[([^\[\]]+)]\(([^()]+)\)""".toRegex()
+
+    fun create(text: String): List<TextToken> {
+      val matches = extractLinkRegex.findAll(text)
+      val regularTokens = matches.toRegularTokens(text)
+      val linkTokens = matches.toLinkTokens()
+      return (regularTokens + linkTokens)
+          .sortedBy { (_, startIndex) -> startIndex }
+          .map { (token, _) -> token }
+          .toList()
+    }
+
+    private fun Sequence<MatchResult>.toLinkTokens() = map { matchResult ->
+      val (text, url) = matchResult.destructured
+      Link(text, url) to matchResult.range.first
+    }
+
+    private fun Sequence<MatchResult>.toRegularTokens(text: String) = toUnmatchedRanges(text)
+        .map { range -> Regular(text.substring(range)) to range.first }
+
+    private fun Sequence<MatchResult>.toUnmatchedRanges(text: String) = sequence {
+      yield(Int.MIN_VALUE..0)
+      yieldAll(map(MatchResult::range).map { it.first - 1..it.last + 1 })
+      yield(text.length - 1..Int.MAX_VALUE)
+    }.windowed(2, 1).map { (start, end) -> start.last..end.first }.filterNot { range -> range.isEmpty() }
+  }
+}
+
+internal fun TextView.setTextTokens(tokens: Iterable<TextToken>) {
+  text = buildSpannedString {
+    for (token in tokens) {
+      token.buildSpan(this)
+    }
+  }
+}

--- a/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelFeatureSpec.kt
+++ b/library/inspector/src/test/java/io/mehow/laboratory/inspector/GroupViewModelFeatureSpec.kt
@@ -10,6 +10,8 @@ import io.mehow.laboratory.Feature
 import io.mehow.laboratory.FeatureFactory
 import io.mehow.laboratory.FeatureStorage
 import io.mehow.laboratory.Laboratory
+import io.mehow.laboratory.inspector.TextToken.Link
+import io.mehow.laboratory.inspector.TextToken.Regular
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 
@@ -135,6 +137,22 @@ internal class GroupViewModelFeatureSpec : DescribeSpec({
         cancel()
       }
     }
+
+    it("uses text tokens for feature flag description") {
+      val viewModel = GroupViewModel(Laboratory.inMemory(), NoSourceFeatureFactory)
+
+      val descriptions = viewModel.observeFeatureGroup().first().map(FeatureUiModel::description)
+
+      descriptions shouldContainExactly listOf(
+          listOf(
+              Regular("Description with a "),
+              Link("link", "https://mehow.io"),
+          ),
+          listOf(
+              Regular("Description without a link"),
+          ),
+      )
+    }
   }
 })
 
@@ -165,6 +183,8 @@ private enum class First : Feature<First> {
   ;
 
   override val defaultOption get() = C
+
+  override val description = "Description with a [link](https://mehow.io)"
 }
 
 private enum class Second : Feature<Second> {
@@ -174,6 +194,8 @@ private enum class Second : Feature<Second> {
   ;
 
   override val defaultOption get() = B
+
+  override val description = "Description without a link"
 }
 
 private enum class Empty : Feature<Empty>

--- a/library/inspector/src/test/java/io/mehow/laboratory/inspector/TextTokenSpec.kt
+++ b/library/inspector/src/test/java/io/mehow/laboratory/inspector/TextTokenSpec.kt
@@ -1,0 +1,83 @@
+package io.mehow.laboratory.inspector
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.data.blocking.forAll
+import io.kotest.data.row
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.mehow.laboratory.inspector.TextToken.Link
+import io.mehow.laboratory.inspector.TextToken.Regular
+
+internal class TextTokenSpec : DescribeSpec({
+  describe("text tokens") {
+    it("can be empty") {
+      TextToken.create("").shouldBeEmpty()
+    }
+
+    it("can be blank") {
+      TextToken.create("   ") shouldContainExactly listOf(
+          Regular("   "),
+      )
+    }
+
+    it("can have regular text") {
+      TextToken.create("Hello") shouldContainExactly listOf(
+          Regular("Hello"),
+      )
+    }
+
+    it("can have link") {
+      TextToken.create("[Hello](https://mehow.io)") shouldContainExactly listOf(
+          Link("Hello", "https://mehow.io"),
+      )
+    }
+
+    it("can start with regular text followed by a link") {
+      TextToken.create("Hello [there](https://github.com/MiSikora/)") shouldContainExactly listOf(
+          Regular("Hello "),
+          Link("there", "https://github.com/MiSikora/"),
+      )
+    }
+
+    it("can start with a link followed by a regular text") {
+      TextToken.create("[General](https://google.com) Kenobi") shouldContainExactly listOf(
+          Link("General", "https://google.com"),
+          Regular(" Kenobi"),
+      )
+    }
+
+    it("can have multiple regular texts and links") {
+      val input = "Hello [there](https://github.com)… [General](https://sample.org) Kenobi"
+      TextToken.create(input) shouldContainExactly listOf(
+          Regular("Hello "),
+          Link("there", "https://github.com"),
+          Regular("… "),
+          Link("General", "https://sample.org"),
+          Regular(" Kenobi"),
+      )
+    }
+
+    it("can have multiple consecutive links") {
+      val input = "[One,](https://one.com)[ Two](https://two.com)[, Three](https://three.com)"
+      TextToken.create(input) shouldContainExactly listOf(
+          Link("One,", "https://one.com"),
+          Link(" Two", "https://two.com"),
+          Link(", Three", "https://three.com"),
+      )
+    }
+
+    it("does not use malformed link syntax") {
+      forAll(
+          row("[One[](https://one.com)"),
+          row("[One](https://one.com()"),
+          row("[](https://one.com"),
+          row("[One]()"),
+          row("[One]((https://one.com)"),
+          row("[O]ne](https://one.com)"),
+          row("[One](h(ttps://one.com)"),
+      ) {
+        TextToken.create(it) shouldContainExactly listOf(Regular(it))
+      }
+    }
+  }
+})

--- a/library/laboratory/src/main/java/io/mehow/laboratory/Feature.kt
+++ b/library/laboratory/src/main/java/io/mehow/laboratory/Feature.kt
@@ -49,7 +49,8 @@ public interface Feature<T> : Comparable<T> where T : Feature<T>, T : Enum<T> {
   @JvmDefault public val source: Class<Feature<*>>? get() = null
 
   /**
-   * Description of the feature flag that can be used for more contextual information.
+   * Description of the feature flag that can be used for more contextual information. Markdown formatted links
+   * will be picked up by the QA module and represented as hyperlinks.
    */
   @JvmDefault public val description: String get() = ""
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -49,6 +49,8 @@ laboratory {
   featureFactory()
 
   feature("LogType") {
+    deprecated("Sample deprecation")
+
     withOption("Verbose")
     withOption("Debug")
     withDefaultOption("Info")
@@ -57,9 +59,7 @@ laboratory {
   }
 
   feature("ReportRootedDevice") {
-    description = "Reports during cold start whether device is rooted"
-
-    deprecated("Sample deprecation")
+    description = "Reports during [cold start](https://developer.android.com/topic/performance/vitals/launch-time#cold) whether device is rooted"
 
     withOption("Enabled")
     withDefaultOption("Disabled")


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

There is an issue – #53.

## :technologist: Changes
<!-- Which code did you change? How? -->

I added a parser for Markdown links in flag descriptions. Token output is then used to build a spannable string.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [x] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/master/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/master/library/docs).
- [x] I updated the [sample](https://github.com/MiSikora/laboratory/tree/master/sample) with relevant changes.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Run automated tests. Check the sample.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

Closes #53.