### PR TITLE
Use description as feature flag's KDoc content

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Use description as feature flag's KDoc content
 - Upgrade Kotlin to `1.4.21`
 
 ### Deprecated

--- a/library/generator/src/main/java/io/mehow/laboratory/generator/FeatureFlagGenerator.kt
+++ b/library/generator/src/main/java/io/mehow/laboratory/generator/FeatureFlagGenerator.kt
@@ -1,6 +1,7 @@
 package io.mehow.laboratory.generator
 
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
@@ -64,14 +65,16 @@ internal class FeatureFlagGenerator(
         .build()
   }
 
-  private val descriptionProperty = feature.description
-      .takeIf { @Kt41142 it.isNotBlank() }
-      ?.let { description ->
-        PropertySpec
-            .builder(descriptionPropertyName, String::class, OVERRIDE)
-            .initializer("%S", description)
-            .build()
-      }
+  private val description: String? = feature.description.takeIf { @Kt41142 it.isNotBlank() }
+
+  private val kdoc = description?.let(CodeBlock::of)
+
+  private val descriptionProperty = description?.let { description ->
+    PropertySpec
+        .builder(descriptionPropertyName, String::class, OVERRIDE)
+        .initializer("%S", description)
+        .build()
+  }
 
   private val typeSpec: TypeSpec = TypeSpec.enumBuilder(feature.className)
       .apply { deprecated?.let { @Kt41142 addAnnotation(it) } }
@@ -95,6 +98,7 @@ internal class FeatureFlagGenerator(
           addProperty(sourceWithOverride)
         }
       }
+      .apply { kdoc?.let { @Kt41142 addKdoc(it) } }
       .apply { descriptionProperty?.let { @Kt41142 addProperty(it) } }
       .build()
 

--- a/library/generator/src/test/java/io/mehow/laboratory/generator/FeatureFlagSpec.kt
+++ b/library/generator/src/test/java/io/mehow/laboratory/generator/FeatureFlagSpec.kt
@@ -603,7 +603,7 @@ internal class FeatureFlagSpec : DescribeSpec({
       }
     }
 
-    it("can have description") {
+    it("can have description doubling as KDoc") {
       val tempDir = createTempDirectory().toFile()
 
       val outputFile = featureBuilder
@@ -617,6 +617,9 @@ internal class FeatureFlagSpec : DescribeSpec({
             |import io.mehow.laboratory.Feature
             |import kotlin.String
             |
+            |/**
+            | * Feature description
+            | */
             |internal enum class FeatureA : Feature<FeatureA> {
             |  First,
             |  Second,

--- a/library/gradle-plugin/src/test/java/io/mehow/laboratory/gradle/GenerateFeatureFlagsTaskSpec.kt
+++ b/library/gradle-plugin/src/test/java/io/mehow/laboratory/gradle/GenerateFeatureFlagsTaskSpec.kt
@@ -536,6 +536,9 @@ internal class GenerateFeatureFlagsTaskSpec : StringSpec({
       |import kotlin.String
       |import kotlin.Suppress
       |
+      |/**
+      | * Feature description
+      | */
       |public enum class Feature : io.mehow.laboratory.Feature<Feature> {
       |  First,
       |  Second,


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->
Allows checking feature flag's description without going to source by using quick documentation shortcut.

## :technologist: Changes
<!-- Which code did you change? How? -->
Changed `FeatureFlagGenerator` to add feature's description as KDoc.

I didn't add new tests, only modified an existing one. I couldn't justify separate cases because _at this moment_ KDoc is tightly bound to description and one will not exist without the other.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [x] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/trunk/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/trunk/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/trunk/sample) with relevant changes.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->
