### PR TITLE
Deprecate DataStore custom builder

### DIFF
--- a/library/data-store/src/main/java/io/mehow/laboratory/datastore/Builder.kt
+++ b/library/data-store/src/main/java/io/mehow/laboratory/datastore/Builder.kt
@@ -15,6 +15,9 @@ import java.io.File
 /**
  * Builder for a [FeatureStorage] backed by [DataStore].
  */
+@Deprecated(
+    message = "This class will be removed in 1.0.0. Use FeatureStorage.Companion.dataStore(DataStore) instead.",
+)
 public class Builder internal constructor(
   private val fileProvider: () -> File,
 ) {
@@ -77,6 +80,13 @@ public class Builder internal constructor(
 /**
  * Creates a [FeatureStorage builder][Builder] with a file taken from [fileProvider].
  */
+@Suppress("DeprecatedCallableAddReplaceWith")
+@Deprecated(
+    message = "" +
+        "This method will be removed in 1.0.0. " +
+        "Configure data store separately using DataStoreFactory " +
+        "and use FeatureStorage.Companion.dataStore(DataStore<FeatureFlags>) instead.",
+)
 public fun FeatureStorage.Companion.dataStoreBuilder(fileProvider: () -> File): Builder {
   return Builder(fileProvider)
 }
@@ -84,6 +94,13 @@ public fun FeatureStorage.Companion.dataStoreBuilder(fileProvider: () -> File): 
 /**
  * Creates a [FeatureStorage builder][Builder] with a file in an apps default directory.
  */
+@Suppress("DeprecatedCallableAddReplaceWith")
+@Deprecated(
+    message = "" +
+        "This method will be removed in 1.0.0. " +
+        "Configure data store separately using DataStoreFactory " +
+        "and use FeatureStorage.Companion.dataStore(DataStore<FeatureFlags>) instead.",
+)
 public fun FeatureStorage.Companion.dataStoreBuilder(context: Context, fileName: String): Builder {
   return dataStoreBuilder { File(context.filesDir, "datastore/$fileName") }
 }

--- a/library/data-store/src/main/java/io/mehow/laboratory/datastore/DataStoreFeatureStorage.kt
+++ b/library/data-store/src/main/java/io/mehow/laboratory/datastore/DataStoreFeatureStorage.kt
@@ -2,6 +2,7 @@ package io.mehow.laboratory.datastore
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
 import io.mehow.laboratory.Feature
 import io.mehow.laboratory.FeatureStorage
 import kotlinx.coroutines.flow.first
@@ -51,12 +52,12 @@ public fun FeatureStorage.Companion.dataStore(dataStore: DataStore<FeatureFlags>
  * Creates a [FeatureStorage] that is backed by [DataStore] with a file taken from [fileProvider].
  */
 public fun FeatureStorage.Companion.dataStore(fileProvider: () -> File): FeatureStorage {
-  return dataStoreBuilder(fileProvider).build()
+  return dataStore(DataStoreFactory.create(FeatureFlagsSerializer, produceFile = fileProvider))
 }
 
 /**
  * Creates a [FeatureStorage] that is backed by [DataStore] with a file in an apps default directory.
  */
 public fun FeatureStorage.Companion.dataStore(context: Context, fileName: String): FeatureStorage {
-  return dataStoreBuilder(context, fileName).build()
+  return dataStore { File(context.filesDir, "datastore/$fileName") }
 }

--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade to DataStore `1.0.0-alpha06`.
 - Upgrade to AGP `4.1.2`.
 
+### Deprecated
+- `DataStore` custom builder and builder factory methods. Factory method that accept `DataStore` directly should be used instead.
+
 ## [0.9.7] - 2020-12-15
 
 ### Changed


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

I don't want to maintain custom builder and coordinate it with changes to `DataStoreFactory`.

## :technologist: Changes
<!-- Which code did you change? How? -->

I deprecated the class and factory methods that rely on the builder.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [ ] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/trunk/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/trunk/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/trunk/sample) with relevant changes.
- [ ] I updated the API `./gradlew -p library apiDump`.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Rely on CI.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

N/A