### PR TITLE
Add parent–child relationship

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add parent–child relationship to `Feature`. This relationship is controlled with a `Feature.supervisorOption` property. Whenever supervisor has its option different from this value then the supervised feature flag cannot return any other option than a default one. Option can still be set via `Laboratory` but it will not be exposed as long as a feature flag is not supervised. This relationship is recursive meaning that grandparents control grandchildren indirectly.
+
 ### Changed
 - Upgrade to DataStore `1.0.0-alpha06`.
 - Upgrade to AGP `4.1.2`.

--- a/library/laboratory/api/laboratory.api
+++ b/library/laboratory/api/laboratory.api
@@ -19,6 +19,7 @@ public abstract interface class io/mehow/laboratory/Feature : java/lang/Comparab
 	public fun getDescription ()Ljava/lang/String;
 	public abstract fun getName ()Ljava/lang/String;
 	public fun getSource ()Ljava/lang/Class;
+	public fun getSupervisorOption ()Lio/mehow/laboratory/Feature;
 }
 
 public abstract interface class io/mehow/laboratory/FeatureFactory {
@@ -34,6 +35,7 @@ public final class io/mehow/laboratory/FeatureKt {
 	public static final fun getDefaultOption (Ljava/lang/Class;)Lio/mehow/laboratory/Feature;
 	public static final fun getDescription (Ljava/lang/Class;)Ljava/lang/String;
 	public static final fun getOptions (Ljava/lang/Class;)[Lio/mehow/laboratory/Feature;
+	public static final fun getParent (Ljava/lang/Class;)Lio/mehow/laboratory/Feature;
 	public static final fun getSource (Ljava/lang/Class;)Ljava/lang/Class;
 }
 

--- a/library/laboratory/api/laboratory.api
+++ b/library/laboratory/api/laboratory.api
@@ -35,8 +35,8 @@ public final class io/mehow/laboratory/FeatureKt {
 	public static final fun getDefaultOption (Ljava/lang/Class;)Lio/mehow/laboratory/Feature;
 	public static final fun getDescription (Ljava/lang/Class;)Ljava/lang/String;
 	public static final fun getOptions (Ljava/lang/Class;)[Lio/mehow/laboratory/Feature;
-	public static final fun getParent (Ljava/lang/Class;)Lio/mehow/laboratory/Feature;
 	public static final fun getSource (Ljava/lang/Class;)Ljava/lang/Class;
+	public static final fun getSupervisorOption (Ljava/lang/Class;)Lio/mehow/laboratory/Feature;
 }
 
 public abstract interface class io/mehow/laboratory/FeatureStorage {

--- a/library/laboratory/src/main/java/io/mehow/laboratory/Feature.kt
+++ b/library/laboratory/src/main/java/io/mehow/laboratory/Feature.kt
@@ -53,6 +53,13 @@ public interface Feature<T> : Comparable<T> where T : Feature<T>, T : Enum<T> {
    * will be picked up by the QA module and represented as hyperlinks.
    */
   @JvmDefault public val description: String get() = ""
+
+  /**
+   * Option of another feature flag that controls value of this child flag. When parent feature flag
+   * has an option different from this value then the child does not produce values other than the default one.
+   * Option can still be set via `Laboratory` but it will not be exposed as long as a feature flag is not supervised.
+   */
+  @JvmDefault public val supervisorOption: Feature<*>? get() = null
 }
 
 /**
@@ -78,6 +85,14 @@ public val Class<Feature<*>>.source: Class<Feature<*>>?
  */
 public val Class<Feature<*>>.description: String
   get() = firstOption.description
+
+/**
+ * Parent of a feature flag.
+ *
+ * @see Feature.supervisorOption
+ */
+public val <T : Feature<T>> Class<T>.parent: Feature<*>?
+  get() = firstOption.supervisorOption
 
 /**
  * All available options of a feature flag.

--- a/library/laboratory/src/main/java/io/mehow/laboratory/Feature.kt
+++ b/library/laboratory/src/main/java/io/mehow/laboratory/Feature.kt
@@ -55,7 +55,7 @@ public interface Feature<T> : Comparable<T> where T : Feature<T>, T : Enum<T> {
   @JvmDefault public val description: String get() = ""
 
   /**
-   * Option of another feature flag that controls value of this child flag. When parent feature flag
+   * Option of another feature flag that controls value of this child flag. When supervisor feature flag
    * has an option different from this value then the child does not produce values other than the default one.
    * Option can still be set via `Laboratory` but it will not be exposed as long as a feature flag is not supervised.
    */
@@ -87,11 +87,11 @@ public val Class<Feature<*>>.description: String
   get() = firstOption.description
 
 /**
- * Parent of a feature flag.
+ * Supervisor of a feature flag.
  *
  * @see Feature.supervisorOption
  */
-public val <T : Feature<T>> Class<T>.parent: Feature<*>?
+public val <T : Feature<T>> Class<T>.supervisorOption: Feature<*>?
   get() = firstOption.supervisorOption
 
 /**

--- a/library/laboratory/src/main/java/io/mehow/laboratory/Laboratory.kt
+++ b/library/laboratory/src/main/java/io/mehow/laboratory/Laboratory.kt
@@ -45,8 +45,8 @@ public class Laboratory internal constructor(
       options.firstOrNull { it.name == expectedName } ?: defaultOption
     }
 
-    val parent = feature.parent ?: return activeOption
-    val activeParentOption = observeRaw(parent.javaClass)
+    val supervisor = feature.supervisorOption ?: return activeOption
+    val activeParentOption = observeRaw(supervisor.javaClass)
 
     return combine(activeOption, activeParentOption) { option, parentOption ->
       if (option.supervisorOption != parentOption) defaultOption else option
@@ -62,8 +62,8 @@ public class Laboratory internal constructor(
       options.firstOrNull { it.name == expectedName } ?: defaultOption
     }
 
-    val parent = feature.parent ?: return activeOption
-    return combine(activeOption, observeRaw(parent.javaClass)) { option, parentOption ->
+    val supervisor = feature.supervisorOption ?: return activeOption
+    return combine(activeOption, observeRaw(supervisor.javaClass)) { option, parentOption ->
       if (option.supervisorOption != parentOption) defaultOption else option
     }.distinctUntilChanged()
   }
@@ -89,7 +89,7 @@ public class Laboratory internal constructor(
     val expectedName = storage.getFeatureName(defaultOption.javaClass) ?: defaultOption.name
     val activeOption = options.firstOrNull { it.name == expectedName } ?: defaultOption
 
-    val parent = feature.parent ?: return activeOption
+    val parent = feature.supervisorOption ?: return activeOption
     return if (activeOption.supervisorOption != experimentRaw(parent.javaClass)) defaultOption else activeOption
   }
 
@@ -99,7 +99,7 @@ public class Laboratory internal constructor(
     val expectedName = storage.getFeatureName(defaultOption.javaClass) ?: defaultOption.name
     val activeOption = options.firstOrNull { it.name == expectedName } ?: defaultOption
 
-    val parent = feature.parent ?: return activeOption
+    val parent = feature.supervisorOption ?: return activeOption
     return if (activeOption.supervisorOption != experimentRaw(parent.javaClass)) defaultOption else activeOption
   }
 

--- a/library/laboratory/src/test/java/io/mehow/laboratory/Features.kt
+++ b/library/laboratory/src/test/java/io/mehow/laboratory/Features.kt
@@ -83,3 +83,41 @@ internal enum class OtherFeature : Feature<OtherFeature> {
 }
 
 internal enum class NoValuesFeature : Feature<NoValuesFeature>
+
+internal enum class GrandParentFeature : Feature<GrandParentFeature> {
+  A,
+  B,
+  ;
+
+  override val defaultOption get() = A
+}
+
+internal enum class ParentFeature : Feature<ParentFeature> {
+  A,
+  B,
+  ;
+
+  override val defaultOption get() = A
+
+  override val supervisorOption = GrandParentFeature.A
+}
+
+internal enum class FirstChildFeature : Feature<FirstChildFeature> {
+  A,
+  B,
+  ;
+
+  override val defaultOption get() = A
+
+  override val supervisorOption = ParentFeature.A
+}
+
+internal enum class SecondChildFeature : Feature<SecondChildFeature> {
+  A,
+  B,
+  ;
+
+  override val defaultOption get() = A
+
+  override val supervisorOption = ParentFeature.B
+}

--- a/library/laboratory/src/test/java/io/mehow/laboratory/ParentChildFeatureSpec.kt
+++ b/library/laboratory/src/test/java/io/mehow/laboratory/ParentChildFeatureSpec.kt
@@ -1,0 +1,103 @@
+package io.mehow.laboratory
+
+import app.cash.turbine.test
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+internal class ParentChildFeatureSpec : DescribeSpec({
+  describe("parent feature") {
+    it("supervises experiments on child") {
+      val laboratory = Laboratory.inMemory()
+
+      laboratory.setOption(FirstChildFeature.B)
+      laboratory.setOption(ParentFeature.B)
+
+      laboratory.experiment<FirstChildFeature>() shouldBe FirstChildFeature.A
+    }
+
+    it("does not change saved child option") {
+      val laboratory = Laboratory.inMemory()
+
+      laboratory.setOption(FirstChildFeature.B)
+      laboratory.setOption(ParentFeature.B)
+      laboratory.setOption(ParentFeature.A)
+
+      laboratory.experiment<FirstChildFeature>() shouldBe FirstChildFeature.B
+    }
+
+    it("does not disable changing child option") {
+      val laboratory = Laboratory.inMemory()
+
+      laboratory.setOption(ParentFeature.B)
+      laboratory.setOption(FirstChildFeature.B)
+      laboratory.setOption(ParentFeature.A)
+
+      laboratory.experiment<FirstChildFeature>() shouldBe FirstChildFeature.B
+    }
+
+    it("supervises observation of child") {
+      val laboratory = Laboratory.inMemory()
+
+      laboratory.setOption(FirstChildFeature.B)
+
+      laboratory.observe<FirstChildFeature>().test {
+        expectItem() shouldBe FirstChildFeature.B
+
+        laboratory.setOption(ParentFeature.B)
+        expectItem() shouldBe FirstChildFeature.A
+
+        laboratory.setOption(ParentFeature.A)
+        expectItem() shouldBe FirstChildFeature.B
+
+        cancel()
+      }
+    }
+
+    it("prevents child from emitting same value twice") {
+      val laboratory = Laboratory.inMemory()
+
+      laboratory.observe<FirstChildFeature>().test {
+        expectItem() shouldBe FirstChildFeature.A
+
+        laboratory.setOption(ParentFeature.B)
+        expectNoEvents()
+
+        cancel()
+      }
+    }
+  }
+
+  describe("grandparent feature") {
+    it("supervises experiments on grandchild") {
+      val laboratory = Laboratory.inMemory()
+
+      laboratory.setOption(SecondChildFeature.B)
+      laboratory.setOption(ParentFeature.B)
+      laboratory.setOption(GrandParentFeature.B)
+
+      laboratory.experiment<SecondChildFeature>() shouldBe SecondChildFeature.A
+    }
+
+    it("supervises observation of grandchild") {
+      val laboratory = Laboratory.inMemory()
+
+      laboratory.setOption(SecondChildFeature.B)
+      laboratory.setOption(ParentFeature.B)
+
+      laboratory.observe<SecondChildFeature>().test {
+        expectItem() shouldBe SecondChildFeature.B
+
+        laboratory.setOption(GrandParentFeature.B)
+        expectItem() shouldBe SecondChildFeature.A
+
+        laboratory.setOption(GrandParentFeature.A)
+        expectItem() shouldBe SecondChildFeature.B
+
+        cancel()
+      }
+    }
+  }
+})
+
+
+

--- a/library/laboratory/src/test/java/io/mehow/laboratory/ParentChildFeatureSpec.kt
+++ b/library/laboratory/src/test/java/io/mehow/laboratory/ParentChildFeatureSpec.kt
@@ -98,6 +98,3 @@ internal class ParentChildFeatureSpec : DescribeSpec({
     }
   }
 })
-
-
-


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

There is an issue – #81.

## :technologist: Changes
<!-- Which code did you change? How? -->

I added `supervisorOption` property to `Feature`. Whenever a feature flag is checked the option of supervisor is also checked to make sure that the child feature can expose values other than the different one. This relationship is recursive meaning that grandparents control grandchildren indirectly.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [x] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/trunk/library/docs/changelog.md).
- [x] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/trunk/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/trunk/sample) with relevant changes.
- [x] I updated the API `./gradlew -p library apiDump`.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Rely on automated tests.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

Closes #81.

Add more tasks to make this feature more user friendly:
* Code generation.
* Gradle plugin API changes.
* Reflect this relationship in inspector's UI.