### PR TITLE
Check for compat types in KyrieImageView

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade to LifecycleViewmodelKtx `2.3.0`.
 - Upgrade to Hyperion `0.9.31`.
 
+### Fixed
+- Search icon not animating on Android below SDK 24.
+
 ### Deprecated
 - `DataStore` custom builder and builder factory methods. Factory method that accepts `DataStore` directly should be used instead.
 

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/KyrieImageView.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/KyrieImageView.kt
@@ -8,6 +8,8 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.Keep
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.res.use
+import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.github.alexjlockwood.kyrie.KyrieDrawable
 
 internal class KyrieImageView @JvmOverloads constructor(
@@ -18,7 +20,7 @@ internal class KyrieImageView @JvmOverloads constructor(
   private var kyrieDrawable: KyrieDrawable? = null
 
   init {
-    if (drawable is VectorDrawable || drawable is AnimatedVectorDrawable) {
+    if (drawable::class in vectorDrawableTypes) {
       @Suppress("CustomViewStyleable")
       context.obtainStyledAttributes(attrs, R.styleable.AppCompatImageView, defStyleAttr, 0).use {
         setImageResource(it.getResourceId(R.styleable.AppCompatImageView_srcCompat, -1))
@@ -39,4 +41,13 @@ internal class KyrieImageView @JvmOverloads constructor(
         coercedValue
       } ?: 0f
     }
+
+  private companion object {
+    val vectorDrawableTypes = setOf(
+        VectorDrawable::class,
+        AnimatedVectorDrawable::class,
+        VectorDrawableCompat::class,
+        AnimatedVectorDrawableCompat::class,
+    )
+  }
 }


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

There is an issue – #99.

## :technologist: Changes
<!-- Which code did you change? How? -->

`KyrieImageView` did not check for `Compat` drawable types when assigning a drawable during initialisation. It does now.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [ ] I wrote tests.
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/trunk/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/trunk/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/trunk/sample) with relevant changes.
- [ ] I updated the API `./gradlew -p library apiDump`.

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Run the sample app on SDK pre 24.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

Closes #99.