### PR TITLE
Show feature's supervisor option in inspector

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Gradle plugin generates `sourcedBuilder()` extension function for `SourcedFeatureStorage` that returns custom builder with steps for each source. This makes changes to sources compile time safe.
+- Show feature's supervisor option in inspector – [#95](https://github.com/MiSikora/laboratory/issues/95).
 
 ### Changed
 - Upgrade to Coroutines `1.4.3`.

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureUiModel.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureUiModel.kt
@@ -24,6 +24,8 @@ internal data class FeatureUiModel(
 
   val isEnabled = isCurrentSourceLocal && isSupervised
 
+  val supervisorName: String? = type.supervisorOption?.fullName
+
   companion object {
     private val firstAlignmentOrdinal = DeprecationAlignment.values().first()
 
@@ -45,3 +47,5 @@ private fun FeatureUiModel.search(query: SearchQuery) = takeIf {
 private val FeatureUiModel.modelNames get() = models.map { it.option.name }
 
 private val FeatureUiModel.sourceNames get() = sources.map { it.option.name }
+
+internal val Feature<*>.fullName get() = "${this::class.simpleName}.$this"

--- a/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureViewHolder.kt
+++ b/library/inspector/src/main/java/io/mehow/laboratory/inspector/FeatureViewHolder.kt
@@ -15,6 +15,7 @@ internal class FeatureViewHolder(
   listener: FeatureAdapter.Listener,
 ) : ViewHolder(itemView) {
   private val name = itemView.findViewById<MaterialTextView>(R.id.io_mehow_laboratory_feature_name)
+  private val supervisor = itemView.findViewById<MaterialTextView>(R.id.io_mehow_laboratory_feature_supervisor)
   private val description = itemView.findViewById<MaterialTextView>(R.id.io_mehow_laboratory_feature_description)
   private val sources = itemView.findViewById<SourceViewGroup>(R.id.io_mehow_laboratory_feature_sources)
   private val divider = itemView.findViewById<View>(R.id.io_mehow_laboratory_sources_divider)
@@ -32,6 +33,10 @@ internal class FeatureViewHolder(
       null, Show -> name.paintFlags and STRIKE_THRU_TEXT_FLAG.inv()
       Strikethrough -> name.paintFlags or STRIKE_THRU_TEXT_FLAG
       Hide -> name.paintFlags
+    }
+    supervisor.isVisible = group.supervisorName != null
+    supervisor.text = group.supervisorName?.let { supervisorName ->
+      itemView.context.getString(R.string.io_mehow_laboratory_feature_supervisor, supervisorName)
     }
     description.setTextTokens(group.description)
     description.isVisible = group.description.isNotEmpty()

--- a/library/inspector/src/main/res/layout/io_mehow_laboratory_feature_item.xml
+++ b/library/inspector/src/main/res/layout/io_mehow_laboratory_feature_item.xml
@@ -24,6 +24,15 @@
         />
 
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/io_mehow_laboratory_feature_supervisor"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/io_mehow_laboratory_spacing"
+        android:paddingBottom="@dimen/io_mehow_laboratory_spacing"
+        android:textAppearance="?textAppearanceCaption"
+        />
+
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/io_mehow_laboratory_feature_description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/library/inspector/src/main/res/values/strings.xml
+++ b/library/inspector/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
   <string name="io_mehow_laboratory_search_features_hint">Search features…</string>
   <string name="io_mehow_laboratory_clear_query">Clear query</string>
   <string name="io_mehow_laboratory_close_search">Close search</string>
+  <string name="io_mehow_laboratory_feature_supervisor">Supervisor: %1$s</string>
 </resources>


### PR DESCRIPTION
## :bulb: Motivation
<!-- Why did you change something? Is there an issue to link here? Or an external link? -->

https://github.com/MiSikora/laboratory/issues/95

## :technologist: Changes
<!-- Which code did you change? How? -->

Simple approach which looks like this:
![image](https://user-images.githubusercontent.com/5305890/111886780-af2b8580-89d0-11eb-8dd9-1c01f6459e07.png)

Notes:
* Enum-like format (i.e. `ChristmasTheme.Enabled`) is easily understandable for both devs, QA and other folks.
* Used standard padding and same text appearance as description. I played a bit with smaller (4dp) padding between feature name and supervisor but it didn't really make a difference. Also tried customizing the text appearance (e.g. `Subtitle2`), but in the end making it uniform with description looked best. 🤷‍♂️ Suggestions welcome though.
* The word `Supervisor` could potentially be changed to something else as the nomenclature is not that obvious for non-devs. Alternatives: "dependent on", "controlled by", "controllable if", etc. What do you think?

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/trunk/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/trunk/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/trunk/sample).

## :test_tube: How to test
<!-- Is there a special case to test your changes? -->

Run the sample app. Optionally other parameters (such as description) can be added to see what it looks like.

## :crystal_ball: Next steps
<!-- Is there something to plan or to do after the merge? Does this PR close any issue? If yes, please add a magic keyword - https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords. -->

Either the issue can stay open or I can create a new one for _improving_ the UI, e.g. showing supervised features in some kind of a tree hierarchy.
