### PR TITLE
Avoid IllegalArgumentException on kotlin 1.7.20

### DIFF
--- a/library/docs/changelog.md
+++ b/library/docs/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed `IllegalArgumentException: Did not find Kotlin source set` after upgrading to kotlin 1.7.20
+
 ## [1.0.1] - 2022-06-21
 
 ### Added

--- a/library/gradle-plugin/src/main/java/io/mehow/laboratory/gradle/SourceSetContribution.kt
+++ b/library/gradle-plugin/src/main/java/io/mehow/laboratory/gradle/SourceSetContribution.kt
@@ -40,9 +40,7 @@ private fun TaskProvider<out Task>.contributeToAndroid(dir: File, project: Proje
   }
   val sources = extension.sourceSets.associate { set -> set.name to set.kotlin }
   for (variant in extension.variants) {
-    val kotlinSourceSet = requireNotNull(sources[variant.name]) {
-      "Did not find Kotlin source set for variant ${variant.name}"
-    }
+    val kotlinSourceSet = sources[variant.name] ?: project.createEmptySourceSet(variant.name)
     kotlinSourceSet.srcDir(dir.toRelativeString(project.projectDir))
     variant.addJavaSourceFoldersToModel(dir)
 
@@ -58,9 +56,7 @@ private fun TaskProvider<out Task>.contributeToAndroid(dir: File, project: Proje
 
 private fun contributeToKotlin(dir: File, project: Project) {
   val sourceSets = project.property("sourceSets") as SourceSetContainer
-  val kotlinSourceSet = requireNotNull(sourceSets.getByName("main").kotlin) {
-    "Did not find Kotlin source set"
-  }
+  val kotlinSourceSet = sourceSets.getByName("main").kotlin ?: project.createEmptySourceSet("empty")
   kotlinSourceSet.srcDir(dir)
 }
 
@@ -83,3 +79,6 @@ private val Any.kotlin: SourceDirectorySet?
   }
 
 private fun Any.getConvention(name: String) = (this as HasConvention).convention.plugins[name]
+
+private fun Project.createEmptySourceSet(name: String) =
+  objects.sourceDirectorySet(name, "Empty kotlin source set")


### PR DESCRIPTION
## :bulb: Motivation
https://github.com/MiSikora/laboratory/issues/284

With kotlin 1.7.20, some of the source sets (that are nullable properties) are actually null. In order to avoid crash, we create an empty source set and use it as a fallback.

## :pencil: Checklist
<!-- Please make sure to go through the checklist and select checkboxes appropriate for your changes. -->
- [x] I updated the [changelog](https://github.com/MiSikora/laboratory/blob/trunk/library/docs/changelog.md).
- [ ] I updated the [documentation](https://github.com/MiSikora/laboratory/tree/trunk/library/docs).
- [ ] I updated the [sample](https://github.com/MiSikora/laboratory/tree/trunk/sample).
