### PR TITLE
Allow any type Features to be set with setOption/setOptions methods

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `BlockingLaboratory.setOption` accepts now `Feature<*>`.
+- `BlockingLaboratory.setOptions` accepts now vararg of `Feature<*>`.
+- `BlockingLaboratory.setOptions` overload accepts now collections of `Feature<*>`.
+
 ## [2.0.2] - 2026-02-01
 
 ### Added

--- a/laboratory/runtime/api/runtime.api
+++ b/laboratory/runtime/api/runtime.api
@@ -15,9 +15,9 @@ public final class io/mehow/laboratory/BlockingLaboratory {
 	public final fun experiment (Ljava/lang/Class;)Ljava/lang/Enum;
 	public final fun experimentIs (Ljava/lang/Enum;)Z
 	public final fun isEnabled (Ljava/lang/Class;)Z
-	public final fun setOption (Ljava/lang/Enum;)Z
+	public final fun setOption (Lio/mehow/laboratory/Feature;)Z
 	public final fun setOptions (Ljava/util/Collection;)Z
-	public final fun setOptions ([Ljava/lang/Enum;)Z
+	public final fun setOptions ([Lio/mehow/laboratory/Feature;)Z
 }
 
 public abstract interface class io/mehow/laboratory/DefaultOptionFactory {

--- a/laboratory/runtime/src/main/kotlin/io/mehow/laboratory/BlockingLaboratory.kt
+++ b/laboratory/runtime/src/main/kotlin/io/mehow/laboratory/BlockingLaboratory.kt
@@ -63,23 +63,19 @@ public class BlockingLaboratory internal constructor(private val laboratory: Lab
 
   /** The blocking equivalent of [Laboratory.setOption]. */
   @BlockingIoCall
-  public fun <T> setOption(option: T): Boolean where T : Feature<T>, T : Enum<out T> = runBlocking {
-    laboratory.setOption(option)
+  public fun setOption(option: Feature<*>): Boolean = runBlocking { laboratory.setOption(option) }
+
+  /** The blocking equivalent of [Laboratory.setOptions]. */
+  @BlockingIoCall
+  public fun setOptions(vararg options: Feature<*>): Boolean = runBlocking {
+    laboratory.setOptions(*options)
   }
 
   /** The blocking equivalent of [Laboratory.setOptions]. */
   @BlockingIoCall
-  public fun <T> setOptions(vararg options: T): Boolean where T : Feature<T>, T : Enum<out T> =
-    runBlocking {
-      laboratory.setOptions(*options)
-    }
-
-  /** The blocking equivalent of [Laboratory.setOptions]. */
-  @BlockingIoCall
-  public fun <T> setOptions(options: Collection<T>): Boolean where T : Feature<T>, T : Enum<out T> =
-    runBlocking {
-      laboratory.setOptions(options)
-    }
+  public fun setOptions(options: Collection<Feature<*>>): Boolean = runBlocking {
+    laboratory.setOptions(options)
+  }
 
   /** The blocking equivalent of [Laboratory.clear]. */
   @BlockingIoCall public fun clear(): Boolean = runBlocking { laboratory.clear() }


### PR DESCRIPTION
Generic constraints (`where` keyword) are a bit problematic in terms of accessing with list of features as list of multiple `Feature` objects (which is a list of anounymous `Features<*>` ) will not fullfill both conditions in compile time